### PR TITLE
fix: path configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,15 @@
       "destination": "/rss.xml"
     }
   ],
+  "trailingSlash": true,
   "redirects": [
     {
       "source": "/:year(\\d{4,})/:month(\\d{2,})/:day(\\d{2,})/:slug",
+      "destination": "/blog/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/:year(\\d{4,})/:month(\\d{2,})/:day(\\d{2,})/:slug/",
       "destination": "/blog/:slug",
       "permanent": true
     }


### PR DESCRIPTION
- trailingSlash is true
-  avoid 404 when `/:year/:month/:day/:slug/` visited